### PR TITLE
Fixing datetime format to display time in 24h

### DIFF
--- a/src/components/date-n-time/date-time-picker-24h.tsx
+++ b/src/components/date-n-time/date-time-picker-24h.tsx
@@ -52,9 +52,9 @@ export function DateTimePicker24h() {
         >
           <CalendarIcon className="mr-2 h-4 w-4" />
           {date ? (
-            format(date, "MM/dd/yyyy hh:mm")
+            format(date, "MM/dd/yyyy HH:mm")
           ) : (
-            <span>MM/DD/YYYY hh:mm</span>
+            <span>MM/DD/YYYY HH:mm</span>
           )}
         </Button>
       </PopoverTrigger>


### PR DESCRIPTION
Hey,

I noticed that there is a tiny bug in the 24 variant of the component. Even though the time can be selected as e.g. 16:40, the time displayed is 4:40 without AM/PM which suggests it's 4 AM.

If I got the code right just changing `hh` to `HH` will fix it. 

Thanks for sharing the components